### PR TITLE
Support for custom log paths on Windows

### DIFF
--- a/uberAgentSupport/uberAgentSupport.psd1
+++ b/uberAgentSupport/uberAgentSupport.psd1
@@ -12,7 +12,7 @@
 RootModule = 'uberAgentSupport.psm1'
 
 # Version number of this module.
-ModuleVersion = '1.1.0'
+ModuleVersion = '1.2.0'
 
 # Supported PSEditions
 # CompatiblePSEditions = @()
@@ -33,7 +33,7 @@ Copyright = '(c) vast limits GmbH. All rights reserved.'
 Description = 'A module for creating an uberAgent support bundle'
 
 # Minimum version of the Windows PowerShell engine required by this module
-PowerShellVersion = '3.0'
+PowerShellVersion = '5.1'
 
 # Name of the Windows PowerShell host required by this module
 # PowerShellHostName = ''
@@ -113,7 +113,7 @@ PrivateData = @{
         # ExternalModuleDependencies = ''
 
     } # End of PSData hashtable
-    
+
  } # End of PrivateData hashtable
 
 # HelpInfo URI of this module


### PR DESCRIPTION
- support for custom log paths on Windows
- Raised required PowerShell version to 5.1 as we use `Get-ItemPropertyValue`
